### PR TITLE
support platforms other than linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN git clone --depth=1 -b v3.5.0 --single-branch https://github.com/neo-project
 RUN git clone --depth=1 -b v3.5.0 --single-branch https://github.com/neo-project/neo.git /tmp/neo
 RUN git clone --depth=1 -b v3.5.0 --single-branch https://github.com/neo-project/neo-modules.git /tmp/neo-modules
 RUN cd /tmp/neo && git apply /tmp/neo.diff
-RUN cd /tmp/neo-node/neo-cli && dotnet remove package Neo && dotnet add reference /tmp/neo/src/Neo/Neo.csproj && dotnet publish --sc --os linux -c Release -o /neo
+RUN cd /tmp/neo-node/neo-cli && dotnet remove package Neo && dotnet add reference /tmp/neo/src/Neo/Neo.csproj && dotnet publish --use-current-runtime -c Release -o /neo
 RUN cd /tmp/neo-modules/src/LevelDBStore && dotnet build -c Release -o /neo/Plugins/LevelDBStore
 
 FROM debian:stable-slim

--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
 # lazynode-neo
+
 lazynode patch of neo
+
+## build
+
+```sh
+docker build . -t lazynode/lazyneo:latest
+```
+
+## use
+
+### store the blockchain data to current work directory
+
+```sh
+docker run -it --rm --name lazyneo -v "$(pwd)":/workspace lazynode/lazyneo:latest
+```
+
+### provide a custom config.json
+
+```sh
+docker run -it --rm --name lazyneo -v "$(pwd)":/workspace -v "$(pwd)/config.json":/neo/config.json lazynode/lazyneo:latest
+```
+
+### provide a custom plugin/module and config.json
+
+* build your own module to somewhere
+
+```sh
+dotnet build -c Release -o $YOUR_MODULE_DIR
+```
+
+* mount your module to the docker
+
+```sh
+docker run -it --rm --name nextdex3.5.0 -v "$(pwd)":/workspace -v "$(pwd)/config.json":/neo/config.json -v $YOUR_MODULE_DIR:/neo/Plugins/$YOUR_MODULE_DIR lazynode/lazyneo:v3.5.0
+```
+
+### fast sync (without data verify)
+
+* download chain.0.acc.zip to current work directory, find package data [here](https://sync.ngd.network/)
+
+* sync data to current directory
+
+```sh
+docker run -it --rm --name lazyneo -v "$(pwd)":/workspace lazynode/lazyneo:latest
+```
+
+* sync faster without verify
+
+```sh
+docker run -it --rm --name lazyneo -v "$(pwd)":/workspace lazynode/lazyneo:latest /neo/neo-cli --noverify
+```
+
+## stop
+
+* Ctrl-C
+* Ctrl-D


### PR DESCRIPTION
use `--use-current-runtime` will set the `--sc` to true by default, plus, we don't need to specify the runtime identifier anymore